### PR TITLE
Fix parserOptions for ESLint v5.x.x

### DIFF
--- a/import/index.js
+++ b/import/index.js
@@ -8,9 +8,8 @@ module.exports = {
     es6: true,
   },
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2018,
     sourceType: 'module',
-    ecmaFeatures: { experimentalObjectRestSpread: true },
   },
   settings: {
     'import/ignore': ['node_modules', '.json$', '.(scss|less|css|styl)$'],


### PR DESCRIPTION
Hi, I get `DeprecationWarning` when I use this config with ESLint v5.x.x.
So I changed rules of that part.
Ref: https://eslint.org/docs/user-guide/migrating-to-5.0.0#experimental-object-rest-spread

Thanks.